### PR TITLE
feat(sponsor): add sponsor information to the main web-site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site
 *.sublime-*
+.idea

--- a/sponsors/enregistrement-sponsor.html
+++ b/sponsors/enregistrement-sponsor.html
@@ -1,0 +1,67 @@
+---
+layout: default
+title: Toulouse JUG - Sponsors
+---
+
+<div class="row">
+    <div class="col-md-8">
+        <h1>Devenir Sponsor</h1>
+
+        <p>
+            Afin de devenir sponsor du ToulouseJUG, vous devez fournir le document suivant <a href="">//TODO : URL vers un doc PDF ou DOCX à stocker sur le github</a> dûment rempli aux organisateurs du JUG.
+        </p>
+
+        <p>Vous pouvez retrouver ci-dessous les différents termes du contrat de sponsoring du JUG Toulousain</p>
+
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">Termes de la convention de Sponsoring</h3>
+            </div>
+            <div class="panel-body">
+                <p>
+                    Cette convention consiste à fixer les engagements de chacun des deux parties dans le cadre d’un plan de sponsor annuel qui couvre la fin de l’année en cours à partir de la date de signature.
+                </p>
+
+                <h4>Engagements : </h4>
+                <ul>
+                    <li>
+                        <span style="font-weight: bolder">Article 1</span>
+                        <p>
+                            <span style="text-decoration: underline;">Le Toulouse JUG s’engage à :</span>
+                            <ul>
+                                <li>
+                                    Mettre le logo du Sponsor sur :
+                                    <ul>
+                                        <li>le Kakemono du Toulouse JUG dès réalisation</li>
+                                        <li>la page des sponsors du site http://toulousejug.org/</li>
+                                        <li>le projecteur au début des conférences et à la fin des conférences</li>
+                                        <li>les T-shirt de l’association dès leur réalisation.</li>
+                                        <li>les emails annonçant les présentations</li>
+                                    </ul>
+                                </li>
+                                <li>Limiter le nombre de sponsors annuels à 5 afin de privilégier l’exposition de ces sponsors. Certaines soirées ou certains événements (comme l’Eclipse Party en 2012), peuvent donner lieu à des sponsoring spécifiques, tout en ne nuisant pas à la visibilité des sponsors annuels.</li>
+                                <li>Juxtaposer un texte d'une taille maximum de 300 caractères (espaces compris) sur la page des sponsors présentant le Sponsor</li>
+                                <li>Permettre au Sponsor de communiquer maximum 10 fois sur la mailing list « announce »par l'intermédiaire du Toulouse JUG, dans la limite d’un mail par mois. Le JUG se réserve le droit de refuser de publier un contenu qu'il ne jugerait pas en adéquation avec l'activité de l'association sans qu'il ne puisse lui en être tenu rigueur. Ces communications peuvent concerner par exemple des offres d’emplois ou des annonces d’événements.</li>
+                                <li>Permettre au sponsor de faire une présentation de type short talk (10 minutes) une fois par trimestre lors d’une des sessions du JUG. Ceci est indépendant des présentations techniques qui peuvent être données par des salariés du sponsor à partir du moment où la proposition de présentation est acceptée par le JUG.</li>
+                            </ul>
+                        </p>
+                    </li>
+                    <li>
+                        <span style="font-weight: bolder;">Article 2</span>
+                        <p>Le Sponsor s’engage à mettre à disposition la somme de 2000 € HT (non asujetti à TVA soit 2000  € TTC), maximum 30 jours après signature de la présente convention, afin de sponsoriser l’association.</p>
+                    </li>
+                    <li>
+                        <span style="font-weight: bolder;">Article 3</span>
+                        <p>Ce partenariat est actif à compter de la date de signature par le partenaire, et jusqu’au 31/12/2012. Son renouvellement, s'il est effectué par la signature d'une nouvelle convention avant l'expiration du présent partenariat, sera prioritaire sur toute autre demande de sponsoring de même niveau effectuée par un autre organisme.</p>
+                    </li>
+                    <li>
+                        <span style="font-weight: bolder;">Article 4</span>
+                        <p>Modalité de rupture si non respect de l’article 1 ou non respect de l’article 2.</p>
+                    </li>
+                </ul>
+            </div>
+        </div>
+
+    </div>
+    {% include right-part.html %}
+</div>

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -17,6 +17,7 @@ activeLink: sponsors
 		  	{% endfor %}
 		</div>
 
+		<a href="{{ site.baseurl }}sponsors/enregistrement-sponsor.html">Comment devenir sponsor du ToulouseJUG ?</a>
 	</div>
 	{% include right-part.html %}
 </div>


### PR DESCRIPTION
Ajout des termes de sponsoring dans une page spécifique atteignable via la page de sponsor (lien en bas).

TODO : Ajouter un document "type" au github (PDF ou doc...) afin de le rendre téléchargeable par des tiers directement.

