### PR TITLE
liens des menus

### DIFF
--- a/_data/menu-header-links.yml
+++ b/_data/menu-header-links.yml
@@ -1,15 +1,15 @@
 - id: accueil
   name: Accueil
-  link:
+  link: /
 - id: about
   name: A propos
-  link: about
+  link: /about
 - id: sponsors
   name: Sponsors
-  link: sponsors
+  link: /sponsors
 - id: trombinoscope
   name: Trombinoscope
-  link: trombinoscope
+  link: /trombinoscope
 - id: videos
   name: Vidéos
-  link: videos
+  link: /videos


### PR DESCRIPTION
La variable {{ site.baseurl }} n'est effectivement plus pris en compte ce qui pose problème pour les posts
En attendant de trouver pourquoi, on force les urls des assets à /
